### PR TITLE
Adds RL support for #33491

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -436,6 +436,7 @@
   --crm-f-fieldset-border: 0;
   --crm-f-fieldset-box-shadow: var(--crm-f-box-shadow);
   --crm-f-legend-position: left; /* chose 'left', 'right' or 'inherit' for browser-default of mid fieldset border */
+  --crm-f-sr-legend-position: absolute; /* chose 'absolute' for inline label/input, and 'unset' for stacked. See #33491 */
   --crm-f-legend-align: left;
   --crm-f-legend-size: var(--crm-r3);
   --crm-f-legend-padding: 0;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -112,7 +112,6 @@
 .crm-container fieldset.crm-sr-fieldset {
   border: 0;
   padding: 0;
-  margin: 0;
 }
 .crm-container fieldset legend {
   font-weight: bold;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -109,6 +109,11 @@
   border: 1px solid var(--crm-fieldset-border-color);
   border-width: var(--crm-fieldset-border);
 }
+.crm-container fieldset.crm-sr-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
 .crm-container fieldset legend {
   font-weight: bold;
   font-family: var(--crm-font-bold);

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -31,6 +31,11 @@
   text-align: var(--crm-f-legend-align);
   float: var(--crm-f-legend-position);
 }
+.crm-container.crm-public fieldset.crm-sr-fieldset legend {
+  padding: 0;
+  font-size: inherit;
+  position: absolute;
+}
 .crm-container.crm-public fieldset legend + * {
   clear: both;
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -14,7 +14,7 @@
 }
 .crm-container.crm-public fieldset:not(.collapsed,
 .crm-inactive-dashlet-fieldset,
-.af-container-style-pane),
+.af-container-style-pane,.crm-sr-fieldset),
 .crm-container.crm-public .crm-event-info-form-block,
 .crm-container.crm-public #crm-profile-block,
 .crm-container.crm-public .crm-container.crm-public .af-container:not(.af-container-style-pane),
@@ -34,7 +34,7 @@
 .crm-container.crm-public fieldset.crm-sr-fieldset legend {
   padding: 0;
   font-size: inherit;
-  position: absolute;
+  position: var(--crm-f-sr-legend-position);
 }
 .crm-container.crm-public fieldset legend + * {
   clear: both;

--- a/ext/riverlea/streams/hackneybrook/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/_variables.css
@@ -141,6 +141,7 @@
   --crm-f-legend-size: var(--crm-r2);
   --crm-f-form-width: 50vw;
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
+  --crm-f-sr-legend-position: var(--crm-f-label-position);
   --crm-f-label-align: left;
   --crm-f-label-margin: 0 var(--crm-s);
   --crm-f-label-width: unset;

--- a/ext/riverlea/streams/thames/_variables.css
+++ b/ext/riverlea/streams/thames/_variables.css
@@ -477,6 +477,7 @@
   --crm-f-form-padding: var(--crm-padding-reg);
   --crm-f-form-layout: block; /* 'grid' = inline, 'block' = stacked */
   --crm-f-label-position: unset;
+  --crm-f-sr-legend-position: var(--crm-f-label-position);
   --crm-f-label-align: left;
   --crm-f-label-weight: bold;
   --crm-f-label-margin: var(--crm-s);

--- a/ext/riverlea/streams/walbrook/_variables.css
+++ b/ext/riverlea/streams/walbrook/_variables.css
@@ -230,6 +230,7 @@
   --crm-f-legend-align: unset;
   --crm-f-legend-size: var(--crm-r2);
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
+  --crm-f-sr-legend-position: var(--crm-f-label-position);
   --crm-f-label-align: left;
   --crm-f-label-margin: var(--crm-s);
   --crm-f-label-width: unset;


### PR DESCRIPTION
Before
----------------------------------------
Legend doesn't look like the Stream's label pattern:

Minetta:
<img width="846" height="245" alt="image" src="https://github.com/user-attachments/assets/0859cec7-32df-4c62-a8ae-56ec35a153ff" />

Walbrook:
<img width="501" height="303" alt="image" src="https://github.com/user-attachments/assets/5bdc075e-9c5c-470e-925a-8313a8ffd521" />

After
----------------------------------------
It does:

Minetta:
<img width="1076" height="512" alt="image" src="https://github.com/user-attachments/assets/6f50db35-59f0-4c73-8ead-3b164021020f" />

Walbrook:
<img width="1644" height="716" alt="image" src="https://github.com/user-attachments/assets/3d0208f0-051b-4d77-99a9-be81d02c6c2a" />

Thames:
<img width="1454" height="600" alt="image" src="https://github.com/user-attachments/assets/5ffcec47-1668-45e2-9f84-ee60f87d9fbb" />

Hackney:
<img width="1258" height="554" alt="image" src="https://github.com/user-attachments/assets/9601198c-961d-4be9-839a-643e28fceb20" />

Technical Details
----------------------------------------
This is fixed for front-end Civi, but not back-end. Can add that but at the moment 33491 seems to focus on Front-end layouts.